### PR TITLE
PMYI-368: Connector schema-010 support

### DIFF
--- a/esco.reference.data.domain/esco.reference.data.domain.csproj
+++ b/esco.reference.data.domain/esco.reference.data.domain.csproj
@@ -7,10 +7,10 @@
     <Authors>Sistemas ESCO</Authors>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <Product>Esco.Reference.Data.Model.NET</Product>
-    <Version>3.3</Version>
+    <Version>3.5</Version>
     <PackageIcon>esco.png</PackageIcon>
     <Description>Dominio de tipos de Datos del Conector ESCO Reference Data</Description>
-    <PackageTags>3.3</PackageTags>
+    <PackageTags>3.5</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.domain/mapping/Acciones.cs
+++ b/esco.reference.data.domain/mapping/Acciones.cs
@@ -49,5 +49,16 @@ namespace ESCO.Reference.Data.Model
         public string closePriceDate { get; set; }
         public string volume { get; set; }
         public string volumeDate { get; set; }
+        public string issueCurrency { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string tickSize { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string settlType { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
+        public string securitySubType { get; set; }
     }
 }

--- a/esco.reference.data.domain/mapping/Cedears.cs
+++ b/esco.reference.data.domain/mapping/Cedears.cs
@@ -49,5 +49,15 @@ namespace ESCO.Reference.Data.Model
         public string closePriceDate { get; set; }
         public string volume { get; set; }
         public string volumeDate { get; set; }
+        public string issueCurrency { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string tickSize { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string settlType { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
     }
 }

--- a/esco.reference.data.domain/mapping/Fondos.cs
+++ b/esco.reference.data.domain/mapping/Fondos.cs
@@ -83,8 +83,8 @@ namespace ESCO.Reference.Data.Model
         public string collateralHaircut { get; set; }
         public string collateralElegible { get; set; }
         public string collateralQuota { get; set; }
-        public string PersonTypeId { get; set; }
-        public string PersonTypeName { get; set; }
+        public string personTypeId { get; set; }
+        public string personTypeName { get; set; }
         public string speciesCode { get; set; }
         public string denomination { get; set; }
 

--- a/esco.reference.data.domain/mapping/Futuros.cs
+++ b/esco.reference.data.domain/mapping/Futuros.cs
@@ -75,6 +75,12 @@ namespace ESCO.Reference.Data.Model
 
         public string minSize { get; set; }
 
+        public string priceScale { get; set; }
+
+        public string sizeScale { get; set; }
+
+        public string settlementDate { get; set; }
+
         public bool execInstValue { get; set; }
     }
 

--- a/esco.reference.data.domain/mapping/Obligaciones.cs
+++ b/esco.reference.data.domain/mapping/Obligaciones.cs
@@ -47,5 +47,15 @@ namespace ESCO.Reference.Data.Model
         public string closePriceDate { get; set; }
         public string volume { get; set; }
         public string volumeDate { get; set; }
+        public string issueCurrency { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string tickSize { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string settlType { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
     }
 }

--- a/esco.reference.data.domain/mapping/Opciones.cs
+++ b/esco.reference.data.domain/mapping/Opciones.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System;
+using System.Text.Json.Serialization;
 
 namespace ESCO.Reference.Data.Model
 {
@@ -22,11 +23,10 @@ namespace ESCO.Reference.Data.Model
     public class OpcionesFields
     {        
         public string cfiCode { get; set; }        
-        public string currency { get; set; }     
-        
+        public string currency { get; set; }            
         public string currency2 { get; set; }
         public string symbol { get; set; }        
-        public string contractMultiplier { get; set; }        
+        public string contractMultiplier { get; set; }
         public string highLimitPrice { get; set; }        
         public string lowLimitPrice { get; set; }        
         public string maturityDate { get; set; }        
@@ -51,27 +51,21 @@ namespace ESCO.Reference.Data.Model
         public string securityStatus { get; set; }
         public string clearingSymbol { get; set; }
         public string optionStyle { get; set; }  
-        
-        public string tickSize { get; set; }    
-
-        public List<TypeTickPriceRules> tickPriceRules { get; set; }
-        
+        public string tickSize { get; set; }   
+        public string settlType {  get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string settlementDate { get; set; }
+        public string putOrCall { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }       
         public string roundLot { get; set; }
-
         public string[] orderTypes { get; set; }
-
         public string[] timeInForces { get; set; }  
-
         public string blockTrade { get; set; }  
-
         public string minLotSize { get; set; }
-
         public string maxLotSize { get; set; }
-
         public string maxSize { get; set; }
-
         public string minSize { get; set; }
-
         public bool execInstValue { get; set; }
 
     }

--- a/esco.reference.data.domain/mapping/Opciones.cs
+++ b/esco.reference.data.domain/mapping/Opciones.cs
@@ -22,51 +22,57 @@ namespace ESCO.Reference.Data.Model
 
     public class OpcionesFields
     {        
-        public string cfiCode { get; set; }        
-        public string currency { get; set; }            
-        public string currency2 { get; set; }
-        public string symbol { get; set; }        
+        public string cfiCode { get; set; }                  
         public string contractMultiplier { get; set; }
+        public string factor { get; set; }
         public string highLimitPrice { get; set; }        
-        public string lowLimitPrice { get; set; }        
-        public string maturityDate { get; set; }        
-        public string factor { get; set; }        
+        public string lowLimitPrice { get; set; }
+        public string maturityDate { get; set; }
+        public string symbol { get; set; }
+        public string issuer { get; set; }
+        public string marketId { get; set; }
+        public string priceLimitType { get; set; }
+        public string securityStatus { get; set; }
+        public string text { get; set; }
+        public string underlyingSecurityId { get; set; }
+        public string country { get; set; }
+        public string isinTicker { get; set; }
+        public string putOrCall { get; set; }
+        public string strikeCurrency { get; set; }
+        public string strikePrice { get; set; }
+        public string strikeValue { get; set; }
+        public string underlyingSymbol { get; set; }
+        public string speciesCode { get; set; }
+        public string denomination { get; set; }
+        public string issueCurrency { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string tickSize { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string settlType { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
+        public string currency { get; set; }
+        public string currency2 { get; set; }
+
+
         public string instrumentSizePrecision { get; set; }        
         public string marketSegmentId { get; set; }        
-        public string tickIncrement { get; set; }        
-        public string underlyingSymbol { get; set; }        
+        public string tickIncrement { get; set; }           
         public string instrumentPricePrecision { get; set; }        
-        public string marketId { get; set; }        
         public string maturityMonthYear { get; set; }        
         public string maxTradeVol { get; set; }        
         public string minPriceIncrement { get; set; }        
-        public string minTradeVol { get; set; }        
-        public string underlyingSecurityId { get; set; }        
-        public string text { get; set; }        
-        public string country { get; set; }        
-        public string priceLimitType { get; set; }        
-        public string issuer { get; set; }        
+        public string minTradeVol { get; set; }                 
         public string bloombergTicker { get; set; }        
-        public string isinTicker { get; set; }        
-        public string securityStatus { get; set; }
         public string clearingSymbol { get; set; }
         public string optionStyle { get; set; }  
-        public string tickSize { get; set; }   
-        public string settlType {  get; set; }
-        public string priceScale { get; set; }
-        public string sizeScale { get; set; }
         public string settlementDate { get; set; }
-        public string putOrCall { get; set; }
-        public List<TypeTickPriceRules> tickPriceRules { get; set; }       
         public string roundLot { get; set; }
-        public string[] orderTypes { get; set; }
-        public string[] timeInForces { get; set; }  
         public string blockTrade { get; set; }  
         public string minLotSize { get; set; }
         public string maxLotSize { get; set; }
-        public string maxSize { get; set; }
-        public string minSize { get; set; }
-        public bool execInstValue { get; set; }
-
     }
 }

--- a/esco.reference.data.domain/mapping/OpcionesMTR.cs
+++ b/esco.reference.data.domain/mapping/OpcionesMTR.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System;
+
+namespace ESCO.Reference.Data.Model
+{
+    public class OpcionesMTR
+    {
+        public OpcionesMTRList data { get; set; }
+        public int? totalCount { get; set; }
+    }
+    public class OpcionesMTRList : List<OpcionMTR> { }
+
+    public class OpcionMTR
+    {
+        public string name { get; set; }
+        public string type { get; set; }
+        public bool? active { get; set; }
+        public OpcionesMTRFields fields { get; set; }
+        public DateTime? updated { get; set; }
+    }
+
+    public class OpcionesMTRFields
+    {        
+        public string cfiCode { get; set; }
+        public string symbol { get; set; }
+        public string contractMultiplier { get; set; }
+        public string highLimitPrice { get; set; }
+        public string lowLimitPrice { get; set; }
+        public string maturityDate { get; set; }           
+        public string factor { get; set; }
+        public string marketSegmentId { get; set; }
+        public string underlyingSymbol { get; set; }
+        public string marketId { get; set; }
+        public string maturityMonthYear { get; set; }
+        public string strikePrice { get; set; }
+        public string strikeCurrency { get; set; }
+        public string blockTrade { get; set; }
+        public string minLotSize { get; set; }
+        public string maxLotSize { get; set; }
+        public string roundLot { get; set; }
+        public string tickSize { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string underlyingSecurityId { get; set; }
+        public string clearingSymbol { get; set; }
+        public string optionStyle { get; set; }
+        public string currency { get; set; }
+        public string country { get; set; }
+        public string priceLimitType { get; set; }
+        public string issuer { get; set; }
+        public string securityStatus { get; set; }
+        public string[] orderTypes { get; set; }    
+        public string[] timeInForces { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string settlementDate { get; set; }
+        public bool execInstValue { get; set; }
+
+
+        public string instrumentSizePrecision { get; set; }
+        public string settlType {  get; set; } 
+        public string currency2 { get; set; }
+        public string tickIncrement { get; set; }
+        public string instrumentPricePrecision { get; set; }
+        public string maxTradeVol { get; set; }
+        public string minPriceIncrement { get; set; }
+        public string volume { get; set; }
+        public string volumeDate { get; set; }
+        public string minTradeVol { get; set; }
+        public string bloombergTicker { get; set; }
+        public string isinTicker { get; set; }
+        public string settlementPrice { get; set; }
+        public string settlementPriceDate { get; set; }
+    }
+}

--- a/esco.reference.data.domain/mapping/OpcionesOTC.cs
+++ b/esco.reference.data.domain/mapping/OpcionesOTC.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace ESCO.Reference.Data.Model
@@ -34,9 +35,11 @@ namespace ESCO.Reference.Data.Model
 
         public string symbol { get; set; }
 
-        public string realtedSymbol { get; set; }
+        public string relatedSymbol { get; set; }
 
         public string contractMultiplier { get; set; }
+
+        public string maturityDate { get; set; }
 
         public string underlyingSymbol { get; set; }
 
@@ -48,9 +51,9 @@ namespace ESCO.Reference.Data.Model
 
         public string marketId { get; set; }    
 
-        public string country { get; set; } 
+        public string country { get; set; }
 
-        public string putOrCall { get; set; }  
+        public string putOrCall { get; set; }
 
     }
 }

--- a/esco.reference.data.domain/mapping/OpcionesOTC.cs
+++ b/esco.reference.data.domain/mapping/OpcionesOTC.cs
@@ -9,7 +9,7 @@ namespace ESCO.Reference.Data.Model
 {
     public class OpcionesOTC
     {
-        public FuturosOTCList data { get; set; }
+        public OpcionesOTCList data { get; set; }
         public int? totalCount { get; set; }    
     }
 

--- a/esco.reference.data.domain/mapping/Pases.cs
+++ b/esco.reference.data.domain/mapping/Pases.cs
@@ -46,6 +46,22 @@ namespace ESCO.Reference.Data.Model
         public string issuer { get; set; }        
         public string bloombergTicker { get; set; }        
         public string isinTicker { get; set; }        
-        public string securityStatus { get; set; } 
+        public string securityStatus { get; set; }
+        public string blockTrade { get; set; }
+        public string minLotSize { get; set; }
+        public string maxLotSize { get; set; }
+        public string roundLot { get; set; }
+        public string tickSize { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
+        public List<TypeLegs> legs { get; set; }
+        public string settlementDate { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public bool execInstValue { get; set; }
+
     }
 }

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -26,8 +26,6 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string strikeValue { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string putOrCall { get; set; }
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string strikeCurrency { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string strikePrice { get; set; }
@@ -198,9 +196,9 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string isShortable { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string personTypeId { get; set; }
+        public string PersonTypeId { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string personTypeName { get; set; }
+        public string PersonTypeName { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string minQty { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -241,6 +239,22 @@ namespace ESCO.Reference.Data.Model
         public bool execInstValue { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string instrumentCode { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string relatedSymbol { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string putOrCall { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string settlType { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string priceScale { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string sizeScale { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string settlementDate { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<TypeLegs> legs { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string securitySubType { get; set; }
     }
 
     public class TypeTickPriceRules
@@ -249,4 +263,13 @@ namespace ESCO.Reference.Data.Model
         public string endTickPriceRange { get; set; }
         public string minPriceIncrement { get; set; }
     }
+
+    public class TypeLegs
+    {
+        public string legSymbol { get; set; }
+        public string legSecurityId { get; set; }
+        public string legSide { get; set; }
+    }
+
+
 }

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -236,7 +236,7 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string minSize { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public dynamic execInstValue { get; set; }
+        public bool execInstValue { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string instrumentCode { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -198,7 +198,7 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string PersonTypeId { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string personTypeName { get; set; }
+        public string PersonTypeName { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string minQty { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -198,7 +198,7 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string PersonTypeId { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string PersonTypeName { get; set; }
+        public string personTypeName { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string minQty { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -236,7 +236,7 @@ namespace ESCO.Reference.Data.Model
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string minSize { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool execInstValue { get; set; }
+        public dynamic execInstValue { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string instrumentCode { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/esco.reference.data.domain/mapping/Titulos.cs
+++ b/esco.reference.data.domain/mapping/Titulos.cs
@@ -49,5 +49,16 @@ namespace ESCO.Reference.Data.Model
         public string closePriceDate { get; set; }
         public string volume { get; set; }
         public string volumeDate { get; set; }
+        public string issueCurrency { get; set; }
+        public string priceScale { get; set; }
+        public string sizeScale { get; set; }
+        public string tickSize { get; set; }
+        public List<TypeTickPriceRules> tickPriceRules { get; set; }
+        public string minSize { get; set; }
+        public string maxSize { get; set; }
+        public string settlType { get; set; }
+        public string[] orderTypes { get; set; }
+        public string[] timeInForces { get; set; }
+        public string securitySubType { get; set; }
     }
 }

--- a/esco.reference.data.domain/responses/Types.cs
+++ b/esco.reference.data.domain/responses/Types.cs
@@ -22,7 +22,7 @@ namespace ESCO.Reference.Data.Model
                                                    //Especies de Fideicomisos GO // Incluido en Type GO y se refiere a TITULOS DE DEUDA, CERTIF. PARTICIP.
         public const string Futuros = "FUT";       //FUT es estándar fix y se refiere a FUTUROS
         public const string Opciones = "OPT";      //OPT y OOF son estándar fix y se refiere a OPCIONES
-        public const string OpcionesF = "OOF";     //OPT y OOF son estándar fix y se refiere a OPCIONES
+        public const string OpcionesMTR = "OOF";     //OPT y OOF son estándar fix y se refiere a OPCIONES
         public const string Pases = "BUYSELL";     //BUYSELL es estándar fix y se refiere a PASES
         public const string Cauciones = "REPO";    //REPO es estándar fix y se refiere a CAUCIONES
         public const string STN = "STN";           //Acciones Privadas
@@ -41,8 +41,8 @@ namespace ESCO.Reference.Data.Model
         public const string Obligaciones = "CORP es estándar fix y se refiere a Obligaciones Negociables";
         public const string Titulos = "Títulos Públicos > Bonos GO GO es estándar fix y se refiere a BONOS EXTERNOS, TITULOS PUBLICOS, BONOS CONSOLIDADOS / Títulos Públicos > Letras GO / Incluido en Type GO y se refiere a LETRAS, LETRAS TESORO NACIONAL / Especies de Fideicomisos GO / Incluido en Type GO y se refiere a TITULOS DE DEUDA, CERTIF. PARTICIP.";
         public const string Futuros = "FUT es estándar fix y se refiere a FUTUROS";
-        public const string Opciones = "OPT y OOF son estándar fix y se refiere a OPCIONES";
-        public const string OpcionesF = "OPT y OOF son estándar fix y se refiere a OPCIONES";
+        public const string Opciones = "OPT es estándar fix y se refiere a OPCIONES BYMA";
+        public const string OpcionesMTR = "OOF se refiere a OPCIONES MTR";
         public const string Pases = "BUYSELL es estándar fix y se refiere a PASES";
         public const string Cauciones = "REPO es estándar fix y se refiere a CAUCIONES";
         public const string STN = "Acciones Privadas";
@@ -68,7 +68,7 @@ namespace ESCO.Reference.Data.Model
                         { new Type() { id = 4, type = Types.Titulos, description = TypesDesc.Titulos } },
                         { new Type() { id = 5, type = Types.Futuros, description = TypesDesc.Futuros } },
                         { new Type() { id = 6, type = Types.Opciones, description = TypesDesc.Opciones } },
-                        { new Type() { id = 7, type = Types.OpcionesF, description = TypesDesc.OpcionesF } },
+                        { new Type() { id = 7, type = Types.OpcionesMTR, description = TypesDesc.OpcionesMTR } },
                         { new Type() { id = 8, type = Types.Pases, description = TypesDesc.Pases } },
                         { new Type() { id = 9, type = Types.Cauciones, description = TypesDesc.Cauciones } },
                         { new Type() { id = 10, type = Types.STN, description = TypesDesc.STN } },

--- a/esco.reference.data.services/config/Config.cs
+++ b/esco.reference.data.services/config/Config.cs
@@ -48,7 +48,6 @@ namespace ESCO.Reference.Data.Config
             public const string FilterMarketId = "indexof(marketId, '{0}') ne -1";
             public const string FilterCountry = "indexof(country, '{0}') ne -1";
 
-            public const string FilterOpts = "?$filter=type eq 'OPT' or type eq 'OOF'";
             public const string FilterADRS = "?$filter=text eq 'A.D.R.S (ACCIONES)'&orderby name";
             public const string FilterPrivadas = "?$filter=text eq 'ACCIONES PRIVADAS'&orderby name";
             public const string FilterPymes = "?$filter=text eq 'ACCIONES PYMES'&orderby name";

--- a/esco.reference.data.services/contracts/IReferenceDataServices.cs
+++ b/esco.reference.data.services/contracts/IReferenceDataServices.cs
@@ -56,7 +56,8 @@ namespace ESCO.Reference.Data.Services.Contracts
         Task<Titulos> GetTitulos(string schema = null);        
         Task<Futuros> GetFuturos(string schema = null);
         Task<FuturosOTC> GetFuturosOTC(string schema = null);
-        Task<ReferenceDatas> GetOpciones(string schema = null);
+        Task<Opciones> GetOpciones(string schema = null);
+        Task<OpcionesMTR> GetOpcionesMTR(string schema = null);
         Task<OpcionesOTC> GetOpcionesOTC(string schema = null);
         Task<Pases> GetPases(string schema = null);
         Task<Cauciones> GetCauciones(string schema = null);

--- a/esco.reference.data.services/esco.reference.data.services.csproj
+++ b/esco.reference.data.services/esco.reference.data.services.csproj
@@ -9,11 +9,11 @@
     <Description>Conector que se integra con el Servicio que ofrece información de referencia de instrumentos financieros</Description>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <PackageIcon>esco.png</PackageIcon>
-    <Version>3.3</Version>
+    <Version>3.5</Version>
     <PackageProjectUrl>https://github.com/matbarofex/esco.reference.data</PackageProjectUrl>
     <RepositoryUrl>https://github.com/matbarofex/esco.reference.data</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>3.3</PackageTags>
+    <PackageTags>3.5</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.services/services/ReferenceDataServices.cs
+++ b/esco.reference.data.services/services/ReferenceDataServices.cs
@@ -236,13 +236,20 @@ namespace ESCO.Reference.Data.Services
              JsonSerializer.Deserialize<FuturosOTC>(await GetAsString(Types.FuturosOTC, schema));
 
         /// <summary>
-        /// Retorna la lista de instrumentos financieros de tipo Opciones (OPT-OOF).
+        /// Retorna la lista de instrumentos financieros de tipo Opciones de ByMA (OPT).
         /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
         /// </summary>     
         /// <returns>Modelo de datos json de tipo Opciones.</returns>
-        public async Task<ReferenceDatas> GetOpciones(string schema = null) =>
-            await GetAsReferenceData(GetUrl(Url.FilterOpts, null, schema));
+        public async Task<Opciones> GetOpciones(string schema = null) =>
+            JsonSerializer.Deserialize<Opciones>(await GetAsString(Types.Opciones, schema));
 
+        /// <summary>
+        /// Retorna la lista de instrumentos financieros de tipo Opciones de MatbaRofex (OOF).
+        /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
+        /// </summary>     
+        /// <returns>Modelo de datos json de tipo OpcionesMTR.</returns>
+        public async Task<OpcionesMTR> GetOpcionesMTR(string schema = null) =>
+            JsonSerializer.Deserialize<OpcionesMTR>(await GetAsString(Types.OpcionesMTR, schema));
 
         /// <summary>
         /// Retorna la lista de instrumentos financieros de tipo OpcionesOTC (OOFOTC).

--- a/esco.reference.data.test/UnitTest.cs
+++ b/esco.reference.data.test/UnitTest.cs
@@ -322,7 +322,17 @@ namespace esco.reference.data.test
         [TestCategory("ByTypes")]
         public void GetOpciones()
         {
-            ReferenceDatas result = services.GetOpciones().Result;
+            Opciones result = services.GetOpciones().Result;
+            Console.Write(JsonSerializer.Serialize(result, options));
+
+            Assert.IsTrue(result.data.Count != 0);
+        }
+
+        [TestMethod]
+        [TestCategory("ByTypes")]
+        public void GetOpcionesMTR()
+        {
+            OpcionesMTR result = services.GetOpcionesMTR().Result;
             Console.Write(JsonSerializer.Serialize(result, options));
 
             Assert.IsTrue(result.data.Count != 0);


### PR DESCRIPTION
Se agregan campos para disponibilizar la información que el schema-010 ofrece, según las discrepancias con la API de ReferenceData. Se adjunta el documento con los campos faltantes.
[camposAgregablesSchema010Libreria.txt](https://github.com/matbarofex/Esco.Reference.Data/files/13877267/camposAgregablesSchema010Libreria.txt)



