### PR TITLE
Actualización de versión de paquetes a 4.8

### DIFF
--- a/esco.reference.data.domain/esco.reference.data.domain.csproj
+++ b/esco.reference.data.domain/esco.reference.data.domain.csproj
@@ -7,10 +7,10 @@
     <Authors>Sistemas ESCO</Authors>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <Product>Esco.Reference.Data.Model.NET</Product>
-    <Version>4.6</Version>
+    <Version>4.8</Version>
     <PackageIcon>esco.png</PackageIcon>
     <Description>Dominio de tipos de Datos del Conector ESCO Reference Data</Description>
-    <PackageTags>4.6</PackageTags>
+    <PackageTags>4.8</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.services/esco.reference.data.services.csproj
+++ b/esco.reference.data.services/esco.reference.data.services.csproj
@@ -9,11 +9,11 @@
     <Description>Conector que se integra con el Servicio que ofrece información de referencia de instrumentos financieros</Description>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <PackageIcon>esco.png</PackageIcon>
-    <Version>4.6</Version>
+    <Version>4.8</Version>
     <PackageProjectUrl>https://github.com/matbarofex/esco.reference.data</PackageProjectUrl>
     <RepositoryUrl>https://github.com/matbarofex/esco.reference.data</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>4.6</PackageTags>
+    <PackageTags>4.8</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Se actualizó la versión de los paquetes en los archivos `esco.reference.data.domain.csproj` y
`esco.reference.data.services.csproj` de `4.6` a `4.8`.

También se actualizó la etiqueta `PackageTags` en ambos archivos para reflejar la nueva versión. Estos cambios preparan el proyecto para la publicación de una nueva versión del software.