### PR TITLE
Soporte para filtro de Treasuries y ajustes en pruebas

### DIFF
--- a/esco.reference.data.domain/esco.reference.data.domain.csproj
+++ b/esco.reference.data.domain/esco.reference.data.domain.csproj
@@ -7,10 +7,10 @@
     <Authors>Sistemas ESCO</Authors>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <Product>Esco.Reference.Data.Model.NET</Product>
-    <Version>4.8</Version>
+    <Version>4.9</Version>
     <PackageIcon>esco.png</PackageIcon>
     <Description>Dominio de tipos de Datos del Conector ESCO Reference Data</Description>
-    <PackageTags>4.8</PackageTags>
+    <PackageTags>4.9</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.services/config/Config.cs
+++ b/esco.reference.data.services/config/Config.cs
@@ -15,7 +15,7 @@ namespace ESCO.Reference.Data.Config
 
         public static class Schema
         {
-            public const string actual = "schema-015";
+            public const string actual = "schema-014";
         }
 
         public class Header
@@ -118,11 +118,16 @@ namespace ESCO.Reference.Data.Config
         }
 
         //Format Url
-        public static string GetUrl(string cfg, string typeorid, string schema, bool search = false, DateTime? daterd = null, bool includeTreasuries = true)
+        public static string GetUrl(string cfg, string typeorid, string schema, bool search = false, DateTime? daterd = null, bool includeTreasuries = false)
         {
             schema ??= Schema.actual;
             string format = (cfg == Url.FilterAdded) ? "d/MM/yyyy" : "yyyy-MM-d";
-            cfg = (cfg == null) ? Url.ReferenceData + Url.FilterAllNeUSA : Url.ReferenceData + cfg;
+            
+            // Si includeTreasuries es true, usar FilterAll en lugar de FilterAllNeUSA
+            cfg = (cfg == null) ? 
+                Url.ReferenceData + (includeTreasuries ? Url.FilterAll : Url.FilterAllNeUSA) : 
+                Url.ReferenceData + cfg;
+            
             string date = (daterd != null)? daterd.Value.ToString(format): DateTime.Now.ToString(format);
             
             string result = (search) ?

--- a/esco.reference.data.services/contracts/IReferenceDataServices.cs
+++ b/esco.reference.data.services/contracts/IReferenceDataServices.cs
@@ -20,8 +20,8 @@ namespace ESCO.Reference.Data.Services.Contracts
         #endregion
 
         #region ReferenceData
-        Task<ReferenceDatas> GetReferenceData(DateTime? date, string type = null, string schema = null);        //Retorna la lista de instrumentos.
-        Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null); //Retorna la lista de instrumentos como una cadena.
+        Task<ReferenceDatas> GetReferenceData(DateTime? date, string type = null, string schema = null, bool treasuries = false);        //Retorna la lista de instrumentos.
+        Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false); //Retorna la lista de instrumentos como una cadena.
         #endregion
 
         #region ESCO     

--- a/esco.reference.data.services/esco.reference.data.services.csproj
+++ b/esco.reference.data.services/esco.reference.data.services.csproj
@@ -9,11 +9,11 @@
     <Description>Conector que se integra con el Servicio que ofrece información de referencia de instrumentos financieros</Description>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <PackageIcon>esco.png</PackageIcon>
-    <Version>4.8</Version>
+    <Version>4.9</Version>
     <PackageProjectUrl>https://github.com/matbarofex/esco.reference.data</PackageProjectUrl>
     <RepositoryUrl>https://github.com/matbarofex/esco.reference.data</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>4.8</PackageTags>
+    <PackageTags>4.9</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.services/services/ReferenceDataServices.cs
+++ b/esco.reference.data.services/services/ReferenceDataServices.cs
@@ -113,12 +113,13 @@ namespace ESCO.Reference.Data.Services
         /// </summary>
         /// <param name="date">(Optional) Filtrar por Fecha de actualizacion de Instrumentos. Si es null devuelve la lista completa.</param>
         /// <param name="type">(Optional) Filtrar por Id del tipo de Instrumentos. Si es null devuelve la lista completa.</param>
-        /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>        
+        /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
+        /// <param name="treasuries">(Optional) Habilitar filtro de treasuries (por defecto false).</param>
         /// <returns>ReferenceDatas json.</returns>
-        public async Task<ReferenceDatas> GetReferenceData(DateTime? date = null, string type = null, string schema = null)
+        public async Task<ReferenceDatas> GetReferenceData(DateTime? date = null, string type = null, string schema = null, bool treasuries = false)
         {
             string cfg = (date != null) ? Url.FilterDated : null;
-            return await GetAsReferenceData(GetUrl(cfg, type, schema, false, date));
+            return await GetAsReferenceData(GetUrl(cfg, type, schema, false, date, treasuries));
         }
 
 
@@ -126,17 +127,18 @@ namespace ESCO.Reference.Data.Services
         /// Retorna la lista de instrumentos financieros como una cadena.
         /// </summary>
         /// <param name="type">(Optional) Filtrar por Id del tipo de Instrumentos. Si es null devuelve la lista completa.</param>
-        /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>        
+        /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
+        /// <param name="treasuries">(Optional) Habilitar filtro de treasuries (por defecto false).</param>
         /// <returns>string</returns>
-        public async Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null) =>
-            await GetAsString(type, schema, null, date);
+        public async Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false) =>
+            await GetAsString(type, schema, null, date, treasuries);
 
-        private async Task<string> GetAsString(string type = null, string schema = null, string cfg = null, DateTime? date = null)
+        private async Task<string> GetAsString(string type = null, string schema = null, string cfg = null, DateTime? date = null, bool treasuries = false)
         {
             try
             {
                 cfg = (date != null) ? Url.FilterDated : cfg;
-                var result = await GetAsReferenceData(GetUrl(cfg, type, schema, false, date));
+                var result = await GetAsReferenceData(GetUrl(cfg, type, schema, false, date, treasuries));
                 var serializedResult = JsonSerializer.Serialize(result, httpClient.Options());
 
                 return serializedResult;

--- a/esco.reference.data.test/UnitTest.cs
+++ b/esco.reference.data.test/UnitTest.cs
@@ -168,6 +168,102 @@ namespace esco.reference.data.test
             
             Assert.IsTrue(allFromUSA, $"All instruments should be from {country}");
         }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataWithTreasuriesFalse_ShouldNotIncludeUSA()
+        {
+            // Arrange
+            bool treasuries = false;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, null, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal instruments (treasuries=false): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            
+            // Verificar que NO hay instrumentos de USA
+            var hasUSAInstruments = result.data != null && result.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsFalse(hasUSAInstruments, "Should NOT return USA instruments when treasuries=false");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataWithTreasuriesTrue_ShouldIncludeUSA()
+        {
+            // Arrange
+            bool treasuries = true;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, null, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal instruments (treasuries=true): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return instruments");
+            
+            // Verificar que SÍ hay instrumentos de USA
+            var hasUSAInstruments = result.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsTrue(hasUSAInstruments, "Should include USA instruments when treasuries=true");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataWithoutTreasuriesParameter_ShouldNotIncludeUSA()
+        {
+            // Arrange & Act - llamada sin parámetro treasuries (valor por defecto: false)
+            ReferenceDatas result = services.GetReferenceData().Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal instruments (default): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            
+            // Verificar que NO hay instrumentos de USA (comportamiento por defecto)
+            var hasUSAInstruments = result.data != null && result.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsFalse(hasUSAInstruments, "Should NOT return USA instruments by default (treasuries not specified)");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void CompareTreasuriesParameter_CountDifference()
+        {
+            // Arrange & Act
+            ReferenceDatas resultWithoutTreasuries = services.GetReferenceData(null, null, null, false).Result;
+            ReferenceDatas resultWithTreasuries = services.GetReferenceData(null, null, null, true).Result;
+            
+            // Assert
+            Console.WriteLine($"Instruments WITHOUT treasuries: {resultWithoutTreasuries.totalCount}");
+            Console.WriteLine($"Instruments WITH treasuries: {resultWithTreasuries.totalCount}");
+            
+            int difference = (resultWithTreasuries.totalCount ?? 0) - (resultWithoutTreasuries.totalCount ?? 0);
+            Console.WriteLine($"Difference (USA instruments): {difference}");
+            
+            Assert.IsTrue(resultWithTreasuries.totalCount > resultWithoutTreasuries.totalCount, 
+                "Should have more instruments when treasuries=true (includes USA)");
+            Assert.IsTrue(difference > 0, "The difference should be the count of USA instruments");
+        }
         #endregion
 
         #region ESCO
@@ -204,6 +300,228 @@ namespace esco.reference.data.test
             string strult = JsonSerializer.Serialize(result, options);
             Console.Write(strult);
 
+        }
+        #endregion
+
+        #region ReferenceData GO Tests
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataWithTreasuriesTrue_ShouldIncludeGOInstruments()
+        {
+            // Arrange
+            bool treasuries = true;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, null, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal instruments (treasuries=true): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return instruments");
+            
+            // Verificar que SÍ hay instrumentos de tipo GO
+            var hasGOInstruments = result.data.Any(d =>
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO");
+            
+            Assert.IsTrue(hasGOInstruments, "Should include GO instruments when treasuries=true");
+            
+            // Contar instrumentos GO
+            int goCount = result.data.Count(d =>
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO");
+            
+            Console.WriteLine($"Total GO instruments: {goCount}");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataWithTreasuriesFalse_ShouldStillIncludeGOInstruments()
+        {
+            // Arrange
+            bool treasuries = false;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, null, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal instruments (treasuries=false): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return instruments");
+            
+            // Verificar que TAMBIÉN hay instrumentos de tipo GO (no son de USA)
+            var hasGOInstruments = result.data.Any(d =>
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO");
+            
+            Assert.IsTrue(hasGOInstruments, "Should include GO instruments when treasuries=false (non-USA GO instruments)");
+            
+            // Contar instrumentos GO
+            int goCount = result.data.Count(d =>
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO");
+            
+            Console.WriteLine($"Total GO instruments (non-USA): {goCount}");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeGO_WithTreasuriesTrue()
+        {
+            // Arrange
+            string type = "GO";
+            bool treasuries = true;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal GO instruments (treasuries=true): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return GO instruments");
+            
+            // Verificar que TODOS los instrumentos son tipo GO
+            var allAreGO = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+            
+            Assert.IsTrue(allAreGO, "All instruments should be of type GO");
+            
+            // Verificar que hay instrumentos de USA (treasuries)
+            var hasUSAInstruments = result.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsTrue(hasUSAInstruments, "Should include USA GO instruments when treasuries=true");
+            
+            Console.WriteLine($"USA GO instruments: {result.data.Count(d => d.fields?.country == "USA")}");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeGO_WithTreasuriesFalse()
+        {
+            // Arrange
+            string type = "GO";
+            bool treasuries = false;
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal GO instruments (treasuries=false): {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return GO instruments");
+            
+            // Verificar que TODOS los instrumentos son tipo GO
+            var allAreGO = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+            
+            Assert.IsTrue(allAreGO, "All instruments should be of type GO");
+            
+            // Verificar que NO hay instrumentos de USA
+            var hasUSAInstruments = result.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsFalse(hasUSAInstruments, "Should NOT include USA GO instruments when treasuries=false");
+            
+            Console.WriteLine($"Non-USA GO instruments: {result.data.Count}");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void CompareGOInstruments_TreasuriesParameter()
+        {
+            // Arrange
+            string type = "GO";
+            
+            // Act
+            ReferenceDatas resultWithoutTreasuries = services.GetReferenceData(null, type, null, false).Result;
+            ReferenceDatas resultWithTreasuries = services.GetReferenceData(null, type, null, true).Result;
+            
+            // Assert
+            Console.WriteLine($"GO instruments WITHOUT treasuries: {resultWithoutTreasuries.totalCount}");
+            Console.WriteLine($"GO instruments WITH treasuries: {resultWithTreasuries.totalCount}");
+            
+            int difference = (resultWithTreasuries.totalCount ?? 0) - (resultWithoutTreasuries.totalCount ?? 0);
+            Console.WriteLine($"Difference (USA GO instruments): {difference}");
+            
+            Assert.IsTrue(resultWithTreasuries.totalCount > resultWithoutTreasuries.totalCount, 
+                "Should have more GO instruments when treasuries=true (includes USA treasuries)");
+            
+            // Verificar que la diferencia son instrumentos GO de USA
+            var usaGOCount = resultWithTreasuries.data.Count(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO" &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Console.WriteLine($"USA GO instruments in treasuries=true result: {usaGOCount}");
+            Assert.AreEqual(difference, usaGOCount, "The difference should equal the count of USA GO instruments");
+            
+            // Verificar que NO hay USA en treasuries=false
+            var nonTreasuriesHasUSA = resultWithoutTreasuries.data.Any(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == "USA");
+            
+            Assert.IsFalse(nonTreasuriesHasUSA, "Result without treasuries should not contain USA instruments");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByCountryUSA_ShouldOnlyReturnGOType()
+        {
+            // Arrange
+            string country = "USA";
+            
+            // Act
+            ReferenceDatas result = services.GetReferenceDataByCountry(country).Result;
+            
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal USA instruments: {result.totalCount}");
+            
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return USA instruments");
+            
+            // Verificar que TODOS los instrumentos de USA son tipo GO
+            var allUSAInstrumentsAreGO = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == "GO");
+            
+            Assert.IsTrue(allUSAInstrumentsAreGO, "All USA instruments should be of type GO (treasuries)");
+            
+            // Verificar que todos son de USA
+            var allFromUSA = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.fields.country) &&
+                d.fields.country == country);
+            
+            Assert.IsTrue(allFromUSA, $"All instruments should be from {country}");
+            
+            Console.WriteLine($"Total USA GO instruments: {result.data.Count}");
         }
         #endregion
     }


### PR DESCRIPTION
Se realizaron los siguientes cambios principales:

- Actualización del esquema predeterminado (`Schema.actual`) de "schema-015" a "schema-014".
- Modificación del método `GetUrl` para incluir el parámetro opcional `includeTreasuries` (por defecto `false`).
- Actualización de las interfaces en `IReferenceDataServices` para soportar el parámetro `treasuries` en los métodos `GetReferenceData` y `GetReferenceDataAsString`.
- Cambios en la implementación de `ReferenceDataServices` para manejar el nuevo parámetro `treasuries`.
- Adición de pruebas unitarias en `UnitTest.cs` para validar el comportamiento con y sin el parámetro `treasuries`, incluyendo casos específicos para instrumentos de tipo `GO` y país `USA`.
- Inclusión de mensajes de consola en las pruebas para facilitar el análisis de resultados.

Estos cambios mejoran el control sobre la inclusión de instrumentos de USA (Treasuries) y aseguran la compatibilidad con el nuevo esquema predeterminado.