### PR TITLE
PMYI-979: Parámetro Instrumentos Segmento TIVA

### DIFF
--- a/esco.reference.data.domain/esco.reference.data.domain.csproj
+++ b/esco.reference.data.domain/esco.reference.data.domain.csproj
@@ -7,10 +7,10 @@
     <Authors>Sistemas ESCO</Authors>
     <Copyright>Sistemas ESCO srl.</Copyright>
     <Product>Esco.Reference.Data.Model.NET</Product>
-    <Version>4.9</Version>
+    <Version>4.10</Version>
     <PackageIcon>esco.png</PackageIcon>
     <Description>Dominio de tipos de Datos del Conector ESCO Reference Data</Description>
-    <PackageTags>4.9</PackageTags>
+    <PackageTags>4.10</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -304,6 +304,8 @@ namespace ESCO.Reference.Data.Model
         public string contractSize { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? dispoMtR { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? extendedTradeSessionEnabled { get; set; }
     }
 
     public class TypeTickPriceRules

--- a/esco.reference.data.domain/mapping/ReferenceData.cs
+++ b/esco.reference.data.domain/mapping/ReferenceData.cs
@@ -304,8 +304,6 @@ namespace ESCO.Reference.Data.Model
         public string contractSize { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? dispoMtR { get; set; }
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public bool? extendedTradeSessionEnabled { get; set; }
     }
 
     public class TypeTickPriceRules

--- a/esco.reference.data.services/config/Config.cs
+++ b/esco.reference.data.services/config/Config.cs
@@ -15,7 +15,7 @@ namespace ESCO.Reference.Data.Config
 
         public static class Schema
         {
-            public const string actual = "schema-014";
+            public const string actual = "schema-015";
         }
 
         public class Header
@@ -44,6 +44,7 @@ namespace ESCO.Reference.Data.Config
             public const string FilterRemoved = "?$filter=updated ge {1} and active eq false";
             public const string FilterAllNeUSA = "?$filter=type ne null and country ne 'USA'";
             public const string treasuries = "&treasuries=true";
+            public const string A3TIVA = "&a3=true";
 
             //Filters OData
             public const string FilterType = "indexof(type, '{0}') ne -1";
@@ -118,7 +119,7 @@ namespace ESCO.Reference.Data.Config
         }
 
         //Format Url
-        public static string GetUrl(string cfg, string typeorid, string schema, bool search = false, DateTime? daterd = null, bool includeTreasuries = false)
+        public static string GetUrl(string cfg, string typeorid, string schema, bool search = false, DateTime? daterd = null, bool includeTreasuries = false, bool includeA3TIVA = false)
         {
             schema ??= Schema.actual;
             string format = (cfg == Url.FilterAdded) ? "d/MM/yyyy" : "yyyy-MM-d";
@@ -140,7 +141,12 @@ namespace ESCO.Reference.Data.Config
             {
                 result += Url.treasuries;
             }
-            
+
+            if(includeA3TIVA)
+            {
+                result += Url.A3TIVA;
+            }
+
             return result;
         }
 

--- a/esco.reference.data.services/contracts/IReferenceDataServices.cs
+++ b/esco.reference.data.services/contracts/IReferenceDataServices.cs
@@ -20,8 +20,8 @@ namespace ESCO.Reference.Data.Services.Contracts
         #endregion
 
         #region ReferenceData
-        Task<ReferenceDatas> GetReferenceData(DateTime? date, string type = null, string schema = null, bool treasuries = false);        //Retorna la lista de instrumentos.
-        Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false); //Retorna la lista de instrumentos como una cadena.
+        Task<ReferenceDatas> GetReferenceData(DateTime? date, string type = null, string schema = null, bool treasuries = false, bool a3 = false);        //Retorna la lista de instrumentos.
+        Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false, bool a3 = false); //Retorna la lista de instrumentos como una cadena.
         #endregion
 
         #region ESCO     

--- a/esco.reference.data.services/services/ReferenceDataServices.cs
+++ b/esco.reference.data.services/services/ReferenceDataServices.cs
@@ -115,11 +115,12 @@ namespace ESCO.Reference.Data.Services
         /// <param name="type">(Optional) Filtrar por Id del tipo de Instrumentos. Si es null devuelve la lista completa.</param>
         /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
         /// <param name="treasuries">(Optional) Habilitar filtro de treasuries (por defecto false).</param>
+        /// <param name="a3">(Optional)  Incorporar instrumentos del segmento TIVA (A3) en la respuesta .</param>
         /// <returns>ReferenceDatas json.</returns>
-        public async Task<ReferenceDatas> GetReferenceData(DateTime? date = null, string type = null, string schema = null, bool treasuries = false)
+        public async Task<ReferenceDatas> GetReferenceData(DateTime? date = null, string type = null, string schema = null, bool treasuries = false, bool a3 = false)
         {
             string cfg = (date != null) ? Url.FilterDated : null;
-            return await GetAsReferenceData(GetUrl(cfg, type, schema, false, date, treasuries));
+            return await GetAsReferenceData(GetUrl(cfg, type, schema, false, date, treasuries, a3));
         }
 
 
@@ -130,7 +131,7 @@ namespace ESCO.Reference.Data.Services
         /// <param name="schema">(Optional) Id del esquema de devolución de la información. Si es null se toma por defecto el esquema activo.</param>
         /// <param name="treasuries">(Optional) Habilitar filtro de treasuries (por defecto false).</param>
         /// <returns>string</returns>
-        public async Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false) =>
+        public async Task<string> GetReferenceDataAsString(DateTime? date = null, string type = null, string schema = null, bool treasuries = false, bool a3 = false) =>
             await GetAsString(type, schema, null, date, treasuries);
 
         private async Task<string> GetAsString(string type = null, string schema = null, string cfg = null, DateTime? date = null, bool treasuries = false)

--- a/esco.reference.data.test/UnitTest.cs
+++ b/esco.reference.data.test/UnitTest.cs
@@ -415,35 +415,143 @@ namespace esco.reference.data.test
             // Arrange
             string type = "GO";
             bool treasuries = false;
-            
+
             // Act
             ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries).Result;
-            
+
             // Assert
             string resultJson = JsonSerializer.Serialize(result, options);
             Console.Write(resultJson);
             Console.WriteLine($"\nTotal GO instruments (treasuries=false): {result.totalCount}");
-            
+
             Assert.IsNotNull(result, "Result should not be null");
             Assert.IsTrue(result.data.Count > 0, "Should return GO instruments");
-            
+
             // Verificar que TODOS los instrumentos son tipo GO
             var allAreGO = result.data.All(d =>
                 d.fields != null &&
                 !string.IsNullOrEmpty(d.type) &&
                 d.type == type);
-            
+
             Assert.IsTrue(allAreGO, "All instruments should be of type GO");
-            
+
             // Verificar que NO hay instrumentos de USA
             var hasUSAInstruments = result.data.Any(d =>
                 d.fields != null &&
                 !string.IsNullOrEmpty(d.fields.country) &&
                 d.fields.country == "USA");
-            
+
             Assert.IsFalse(hasUSAInstruments, "Should NOT include USA GO instruments when treasuries=false");
-            
+
             Console.WriteLine($"Non-USA GO instruments: {result.data.Count}");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeCORP_withTIVA()
+        {
+            // Arrange
+            string type = "CORP";
+            bool treasuries = false;
+            bool a3 = true;
+
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries, a3).Result;
+
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal CORP instruments (a3=true): {result.totalCount}");
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return CORP instruments");
+
+            // Verificar que TODOS los instrumentos son tipo CORP
+            var allAreCORP = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+
+            Assert.IsTrue(allAreCORP, "All instruments should be of type CORP");
+
+            // Verificar que el filtro a3 está funcionando (al menos un registro debe ser del segmento TIVA)
+            var atLeastOneTIVAInstrument = result.data.Any(d =>
+                d.fields != null &&
+                d.fields.marketId == "A3");
+
+            Assert.IsTrue(atLeastOneTIVAInstrument, "Should include at least one TIVA instrument when a3=true");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeCS_withTIVA()
+        {
+            // Arrange
+            string type = "CS";
+            bool treasuries = false;
+            bool a3 = true;
+
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries, a3).Result;
+
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal CS instruments (a3=true): {result.totalCount}");
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return CS instruments");
+
+            // Verificar que TODOS los instrumentos son tipo CORP
+            var allAreCORP = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+
+            Assert.IsTrue(allAreCORP, "All instruments should be of type CS");
+
+            // Verificar que el filtro a3 está funcionando (al menos un registro debe ser del segmento TIVA)
+            var atLeastOneTIVAInstrument = result.data.Any(d =>
+                d.fields != null &&
+                d.fields.marketId == "A3");
+
+            Assert.IsTrue(atLeastOneTIVAInstrument, "Should include at least one TIVA instrument when a3=true");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeGO_withTIVA()
+        {
+            // Arrange
+            string type = "GO";
+            bool treasuries = false;
+            bool a3 = true;
+
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries, a3).Result;
+
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal GO instruments (a3=true): {result.totalCount}");
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return GO instruments");
+
+            // Verificar que TODOS los instrumentos son tipo CORP
+            var allAreCORP = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+
+            Assert.IsTrue(allAreCORP, "All instruments should be of type GO");
+
+            // Verificar que el filtro a3 está funcionando (al menos un registro debe ser del segmento TIVA)
+            var atLeastOneTIVAInstrument = result.data.Any(d =>
+                d.fields != null &&
+                d.fields.marketId == "A3");
+
+            Assert.IsTrue(atLeastOneTIVAInstrument, "Should include at least one TIVA instrument when a3=true");
         }
 
         [TestMethod]

--- a/esco.reference.data.test/UnitTest.cs
+++ b/esco.reference.data.test/UnitTest.cs
@@ -502,7 +502,7 @@ namespace esco.reference.data.test
             Assert.IsNotNull(result, "Result should not be null");
             Assert.IsTrue(result.data.Count > 0, "Should return CS instruments");
 
-            // Verificar que TODOS los instrumentos son tipo CORP
+            // Verificar que TODOS los instrumentos son tipo CS
             var allAreCORP = result.data.All(d =>
                 d.fields != null &&
                 !string.IsNullOrEmpty(d.type) &&
@@ -538,7 +538,7 @@ namespace esco.reference.data.test
             Assert.IsNotNull(result, "Result should not be null");
             Assert.IsTrue(result.data.Count > 0, "Should return GO instruments");
 
-            // Verificar que TODOS los instrumentos son tipo CORP
+            // Verificar que TODOS los instrumentos son tipo GO
             var allAreCORP = result.data.All(d =>
                 d.fields != null &&
                 !string.IsNullOrEmpty(d.type) &&
@@ -552,6 +552,35 @@ namespace esco.reference.data.test
                 d.fields.marketId == "A3");
 
             Assert.IsTrue(atLeastOneTIVAInstrument, "Should include at least one TIVA instrument when a3=true");
+        }
+
+        [TestMethod]
+        [TestCategory("ReferenceData")]
+        public void GetReferenceDataByTypeMF()
+        {
+            // Arrange
+            string type = "MF";
+            bool treasuries = false;
+            bool a3 = false;
+
+            // Act
+            ReferenceDatas result = services.GetReferenceData(null, type, null, treasuries, a3).Result;
+
+            // Assert
+            string resultJson = JsonSerializer.Serialize(result, options);
+            Console.Write(resultJson);
+            Console.WriteLine($"\nTotal MF instruments: {result.totalCount}");
+
+            Assert.IsNotNull(result, "Result should not be null");
+            Assert.IsTrue(result.data.Count > 0, "Should return MF instruments");
+
+            // Verificar que TODOS los instrumentos son tipo MF
+            var allAreMF = result.data.All(d =>
+                d.fields != null &&
+                !string.IsNullOrEmpty(d.type) &&
+                d.type == type);
+
+            Assert.IsTrue(allAreMF, "All instruments should be of type MF");
         }
 
         [TestMethod]


### PR DESCRIPTION
Se ajusta el código del conector para permitir la inserción del parámetro booleano "a3" en la consulta OData para la visualización de instrumentos del segmento TIVA (A3) que se suman en los siguientes tipos de instrumentos:
- Acciones (CS)
- Obligaciones Negociables (CORP)
- Títulos Públicos (GO)
- Fideicomisos Financieros (FT)